### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Software for the "data donation" project OpenSCHUFA by Open Knowledge Foundation Germany and AlgorithmWatch.
 
-https://www.openschufa.de
+https://openschufa.de


### PR DESCRIPTION
Change link to https://openschufa.de . The link https://www.openschufa.de will yield an error message in Firefox as the used (non-wildcard) SSL certificate does not match properly.